### PR TITLE
Fixing LXDE (Ubuntu)'s entry as Lubuntu is based on LXQt and Ubuntu

### DIFF
--- a/rhino-deinst
+++ b/rhino-deinst
@@ -26,7 +26,7 @@ SELECTED=($( dialog --backtitle "Press 'space' to toggle an option, use arrow ke
   "17" "Openbox" OFF \
   "18" "UKUI" OFF \
   "19" "Phosh core" OFF \
-  "20" "LXDE (Ubuntu)" OFF \
+  "20" "LXQt (Ubuntu)" OFF \
   "21" "LXDE" OFF \
   "22" "XFCE (Ubuntu)" OFF \
   "23" "Enlightenment" OFF \


### PR DESCRIPTION
LXDE isn't on Lubuntu so I renamed the entry to LXQt (Ubuntu)