### PR TITLE
upd(unity): `ubuntu-unity-desktop` -> `unity`

### DIFF
--- a/rhino-deinst
+++ b/rhino-deinst
@@ -80,9 +80,9 @@ for i in "${SELECTED[@]}"; do
       login_manager="lightdm"
       ;;
     12)
-      desktop+=("ubuntu-unity-desktop")
+      desktop+=("unity")
       login_manager="lightdm"
-      extra_packages="dbus-x11 yaru-theme-unity unity-tweak-tool"
+      extra_packages="dbus-x11 yaru-theme-unity unity-tweak-tool unity-lens-applications unity-lens-files unity-scopes-runner libzeitgeist-1.0-1 unity-accessibility-profiles vlc pluma mate-system-monitor atril"
       ;;
     13)
       desktop+=("sway")

--- a/rhino-deinst
+++ b/rhino-deinst
@@ -18,7 +18,7 @@ SELECTED=($( dialog --backtitle "Press 'space' to toggle an option, use arrow ke
   "9" "LXQT" OFF \
   "10" "Budgie" OFF \
   "11" "i3" OFF \
-  "12" "Unity (Ubuntu)" OFF \
+  "12" "Unity" OFF \
   "13" "Sway" OFF \
   "14" "AwesomeWM" OFF \
   "15" "bspwm" OFF \


### PR DESCRIPTION
I just found out that there are two packages by which Unity can be installed: `ubuntu-unity-desktop` and `unity`. What I have done in this PR is update Unity to install the `unity` package and add other apps to the extra packages flag that better fit Unity's UI, like Rudra did for the 22.04 release of Ubuntu Unity. This makes it so that Unity isn't dependent on GNOME apps to keep it installed, and it makes the UI just look naturally nicer