### PR TITLE
feat!: organize tool

### DIFF
--- a/rhino-deinst
+++ b/rhino-deinst
@@ -20,18 +20,19 @@ SELECTED=($( dialog --backtitle "Press 'space' to toggle an option, use arrow ke
   "11" "LXQt" OFF \
   "12" "Budgie (Ubuntu)" OFF \
   "13" "Budgie" OFF \
-  "14" "Unity" OFF \
-  "15" "Cinnamon" OFF \
-  "16" "Phosh core" OFF \
-  "17" "UKUI" OFF \
-  "18" "LXDE" OFF \
-  "19" "i3" OFF \
-  "20" "Sway" OFF \
-  "21" "AwesomeWM" OFF \
-  "22" "bspwm" OFF \
-  "23" "DWM" OFF \
-  "24" "Openbox" OFF \
-  "25" "Enlightenment" OFF \
+  "14" "Unity (Ubuntu)" OFF \
+  "15" "Unity" OFF \
+  "16" "Cinnamon" OFF \
+  "17" "Phosh core" OFF \
+  "18" "UKUI" OFF \
+  "19" "LXDE" OFF \
+  "20" "i3" OFF \
+  "21" "Sway" OFF \
+  "22" "AwesomeWM" OFF \
+  "23" "bspwm" OFF \
+  "24" "DWM" OFF \
+  "25" "Openbox" OFF \
+  "26" "Enlightenment" OFF \
   
   3>&1 1>&2 2>&3))
 
@@ -91,52 +92,57 @@ for i in "${SELECTED[@]}"; do
       login_manager="budgie-lightdm-theme-base"
       ;; 
     14)
+      desktop+=("ubuntu-unity-desktop")
+      login_manager="lightdm"
+      extra_packages="dbus-x11 yaru-theme-unity unity-tweak-tool"
+      ;;
+    15)
       desktop+=("unity")
       login_manager="lightdm"
       extra_packages="dbus-x11 yaru-theme-unity unity-tweak-tool unity-lens-applications unity-lens-files unity-scopes-runner libzeitgeist-1.0-1 unity-accessibility-profiles vlc pluma mate-system-monitor atril eom"
       ;;
-    15)
+    16)
       desktop+=("cinnamon")
       login_manager="lightdm"
       ;; 
-    16)
+    17)
       desktop+=("phose-core")
       login_manager="gdm3"
       ;;
-    17)
+    18)
       desktop+=("ukui-desktop-environment")
       login_manager="ukui-greeter"
       extra_packages="obconf"
       ;;
-    18)
+    19)
       desktop+=("lxde")
       login_manager="lxdm"
       ;;
-    19)
+    20)
       desktop+=("i3")
       login_manager="lightdm"
       ;; 
-    20)
+    21)
       desktop+=("sway")
       login_manager="sddm"
       ;; 
-    21)
+    22)
       desktop+=("awesome")
       login_manager="lightdm"
       ;;
-    22)
+    23)
       desktop+=("bspwm")
       login_manager="lightdm"
       ;;
-    23)
+    24)
       desktop+=("dwm")
       login_manager="lightdm"
       ;;
-    24)
+    25)
       desktop+=("openbox")
       login_manager="lightdm"
       extra_packages="obconf"
-    25)
+    26)
       desktop+=("enlightenment")
       login_manager="lightdm"
       ;;

--- a/rhino-deinst
+++ b/rhino-deinst
@@ -31,6 +31,7 @@ SELECTED=($( dialog --backtitle "Press 'space' to toggle an option, use arrow ke
   "22" "XFCE (Ubuntu)" OFF \
   "23" "Enlightenment" OFF \
   "24" "GNOME Flashback" OFF \
+  "25" "Budgie (Ubuntu)" OFF \
   3>&1 1>&2 2>&3))
 
 for i in "${SELECTED[@]}"; do
@@ -132,6 +133,9 @@ for i in "${SELECTED[@]}"; do
     24)
       desktop+=("gnome-session-flashback")
       login_manager="gdm3"
+    25)
+      desktop+=("ubuntu-budgie-desktop")
+      login_manager="budgie-lightdm-theme-base"
       ;;
   esac
 done

--- a/rhino-deinst
+++ b/rhino-deinst
@@ -8,30 +8,31 @@ fi
 
 SELECTED=($( dialog --backtitle "Press 'space' to toggle an option, use arrow keys to go up/down, press enter to continue" --erase-on-exit --scrollbar --separate-output --checklist "Select Desktop Environment(s)" 10 35 5 \
   "1" "GNOME (Ubuntu)" OFF \
-  "2" "GNOME" OFF \
-  "3" "KDE (Full)" OFF \
-  "4" "KDE (Standard)" OFF \
-  "5" "XFCE" OFF \
-  "6" "MATE" OFF \
-  "7" "MATE (Ubuntu)" OFF \
-  "8" "Cinnamon" OFF \
-  "9" "LXQT" OFF \
-  "10" "Budgie" OFF \
-  "11" "i3" OFF \
-  "12" "Unity" OFF \
-  "13" "Sway" OFF \
-  "14" "AwesomeWM" OFF \
-  "15" "bspwm" OFF \
-  "16" "DWM" OFF \
-  "17" "Openbox" OFF \
-  "18" "UKUI" OFF \
-  "19" "Phosh core" OFF \
-  "20" "LXDE (Ubuntu)" OFF \
-  "21" "LXDE" OFF \
-  "22" "XFCE (Ubuntu)" OFF \
-  "23" "Enlightenment" OFF \
-  "24" "GNOME Flashback" OFF \
-  "25" "Budgie (Ubuntu)" OFF \
+  "2" "GNOME Flashback" OFF \
+  "3" "GNOME" OFF \
+  "4" "KDE (Full)" OFF \
+  "5" "KDE (Standard)" OFF \
+  "6" "XFCE (Ubuntu)" OFF \
+  "7" "XFCE" OFF \
+  "8" "MATE (Ubuntu)" OFF \
+  "9" "MATE" OFF \
+  "10" "LXQt (Ubuntu)" OFF \
+  "11" "LXQt" OFF \
+  "12" "Budgie (Ubuntu)" OFF \
+  "13" "Budgie" OFF \
+  "14" "Unity" OFF \
+  "15" "Cinnamon" OFF \
+  "16" "Phosh core" OFF \
+  "17" "UKUI" OFF \
+  "18" "LXDE" OFF \
+  "19" "i3" OFF \
+  "20" "Sway" OFF \
+  "21" "AwesomeWM" OFF \
+  "22" "bspwm" OFF \
+  "23" "DWM" OFF \
+  "24" "Openbox" OFF \
+  "25" "Enlightenment" OFF \
+  
   3>&1 1>&2 2>&3))
 
 for i in "${SELECTED[@]}"; do
@@ -41,101 +42,103 @@ for i in "${SELECTED[@]}"; do
       login_manager="gdm3"
       ;;
     2)
-      desktop+=("vanilla-gnome-desktop")
+      desktop+=("gnome-session-flashback")
       login_manager="gdm3"
       ;;
     3)
+      desktop+=("vanilla-gnome-desktop")
+      login_manager="gdm3"
+      ;;
+    4)
       desktop+=("kde-full")
       login_manager="sddm"
       ;;
-    4)
+    5)
       desktop+=("kde-standard")
       login_manager="sddm"
       ;;
-    5)
-      desktop+=("xfce4" "xfce4-goodies")
-      login_manager="lightdm"
-      ;;
     6)
-      desktop+=("mate-desktop")
-      login_manager="lightdm"
-      ;;
-    7)
-      desktop+=("ubuntu-mate-desktop")
-      login_manager="lightdm"
-      ;;
-    8)
-      desktop+=("cinnamon")
-      login_manager="lightdm"
-      ;;
-    9)
-      desktop+=("lxqt")
-      login_manager="sddm"
-      ;;
-    10)
-      desktop+=("budgie-desktop")
-      login_manager="budgie-lightdm-theme-base"
-      ;;
-    11)
-      desktop+=("i3")
-      login_manager="lightdm"
-      ;;
-    12)
-      desktop+=("unity")
-      login_manager="lightdm"
-      extra_packages="dbus-x11 yaru-theme-unity unity-tweak-tool unity-lens-applications unity-lens-files unity-scopes-runner libzeitgeist-1.0-1 unity-accessibility-profiles vlc pluma mate-system-monitor atril"
-      ;;
-    13)
-      desktop+=("sway")
-      login_manager="sddm"
-      ;; 
-    14)
-      desktop+=("awesome")
-      login_manager="lightdm"
-      ;;
-    15)
-      desktop+=("bspwm")
-      login_manager="lightdm"
-      ;; 
-    16)
-      desktop+=("dwm")
-      login_manager="lightdm"
-      ;;
-    17)
-      desktop+=("openbox")
-      login_manager="lightdm"
-      extra_packages="obconf"
-      ;;
-    18)
-      desktop+=("ukui-desktop-environment")
-      login_manager="ukui-greeter"
-      ;;
-    19)
-      desktop+=("phosh-core")
-      login_manager="gdm3"
-      ;; 
-    20)
-      desktop+=("lubuntu-desktop")
-      login_manager="lxdm"
-      ;; 
-    21)
-      desktop+=("lxde")
-      login_manager="lxdm"
-      ;;
-    22)
       desktop+=("xubuntu-desktop")
       login_manager="lightdm"
       ;;
+    7)
+      desktop+=("xfce4" "xfce4-goodies")
+      login_manager="lightdm"
+      ;;
+    8)
+      desktop+=("ubuntu-mate-desktop")
+      login_manager="lightdm"
+      ;;
+    9)
+      desktop+=("mate-desktop")
+      login_manager="lightdm"
+      ;;
+    10)
+      desktop+=("lubuntu-desktop")
+      login_manager="sddm"
+      ;;
+    11)
+      desktop+=("lxqt")
+      login_manager="sddm"
+      ;;
+    12)
+      desktop+=("ubuntu-budgie-desktop")
+      login_manager="budgie-lightdm-theme-base"
+      
+      ;;
+    13)
+      desktop+=("budgie-desktop")
+      login_manager="budgie-lightdm-theme-base"
+      ;; 
+    14)
+      desktop+=("unity")
+      login_manager="lightdm"
+      extra_packages="dbus-x11 yaru-theme-unity unity-tweak-tool unity-lens-applications unity-lens-files unity-scopes-runner libzeitgeist-1.0-1 unity-accessibility-profiles vlc pluma mate-system-monitor atril eom"
+      ;;
+    15)
+      desktop+=("cinnamon")
+      login_manager="lightdm"
+      ;; 
+    16)
+      desktop+=("phose-core")
+      login_manager="gdm3"
+      ;;
+    17)
+      desktop+=("ukui-desktop-environment")
+      login_manager="ukui-greeter"
+      extra_packages="obconf"
+      ;;
+    18)
+      desktop+=("lxde")
+      login_manager="lxdm"
+      ;;
+    19)
+      desktop+=("i3")
+      login_manager="lightdm"
+      ;; 
+    20)
+      desktop+=("sway")
+      login_manager="sddm"
+      ;; 
+    21)
+      desktop+=("awesome")
+      login_manager="lightdm"
+      ;;
+    22)
+      desktop+=("bspwm")
+      login_manager="lightdm"
+      ;;
     23)
-      desktop+=("enlightenment")
+      desktop+=("dwm")
       login_manager="lightdm"
       ;;
     24)
-      desktop+=("gnome-session-flashback")
-      login_manager="gdm3"
+      desktop+=("openbox")
+      login_manager="lightdm"
+      extra_packages="obconf"
     25)
-      desktop+=("ubuntu-budgie-desktop")
-      login_manager="budgie-lightdm-theme-base"
+      desktop+=("enlightenment")
+      login_manager="lightdm"
       ;;
   esac
 done


### PR DESCRIPTION
This PR resolves #16 and organizes the tool itself. 

Desktop environments are now categorized on top, and window managers are on the bottom, so now when you scroll through the list, it isn't just whatever mixed around, you now go through the DEs first, and then the WMs options next.

DEs are now organized by group. For example, `GNOME (Ubuntu)`, `GNOME Flashback` and `GNOME` are now all 1, 2, and 3 on the list. `XFCE (Ubuntu)` and `XFCE` are next to each other, Budgie options, and so forth. DEs that did not have an Ubuntu config were placed near the end of the DE section of the list

PR #18 also got included in this PR, so keeping that open was no longer necessary. 