### PR TITLE
feat: Unity tweaks

### DIFF
--- a/rhino-deinst
+++ b/rhino-deinst
@@ -99,6 +99,7 @@ for i in "${SELECTED[@]}"; do
       desktop+=("unity")
       login_manager="lightdm"
       extra_packages="dbus-x11 yaru-theme-unity unity-tweak-tool unity-lens-applications unity-lens-files unity-scopes-runner libzeitgeist-1.0-1 unity-accessibility-profiles vlc pluma mate-system-monitor atril eom"
+      remove_packages="totem eog nautilus gnome-system-monitor gnome-text-editor gedit"
       ;;
     16)
       desktop+=("cinnamon")
@@ -173,6 +174,8 @@ fi
 
 echo "Installing desktop and login manager..."
 sudo apt-get install -y ${desktop[@]} "${login_manager}" ${extra_packages}
+echo "Removing unessecary packages"
+sudo apt remove -y ${remove_packages}
 echo "Set login manager to $login_manager"
 sudo dpkg-reconfigure "${login_manager}"
 echo "Done!"

--- a/rhino-deinst
+++ b/rhino-deinst
@@ -185,6 +185,10 @@ if [[ ${desktop[@]} = "unity" ]]; then
   echo 'deb https://repo.unityx.org/main testing main' | sudo tee /etc/apt/sources.list.d/unity-x.list
   sudo apt-get update && sudo apt-get install -y unity
   fi
+if false [[ ${desktop[@]} = "ubuntu-desktop gnome-session-flashback vanilla-gnome-desktop" ]]; then
+  echo "Removing gnome-shell"
+  sudo apt autoremove '^gnome-shell' --purge -y
+fi
 echo "Set login manager to $login_manager"
 sudo dpkg-reconfigure "${login_manager}"
 echo "Done!"

--- a/rhino-deinst
+++ b/rhino-deinst
@@ -174,8 +174,10 @@ fi
 
 echo "Installing desktop and login manager..."
 sudo apt-get install -y ${desktop[@]} "${login_manager}" ${extra_packages}
-echo "Removing unessecary packages"
-sudo apt remove -y ${remove_packages}
+if [[ -n $remove_packages ]]; then
+    echo "Removing unnecessary packages"
+    sudo apt remove -y ${remove_packages}
+fi
 echo "Set login manager to $login_manager"
 sudo dpkg-reconfigure "${login_manager}"
 echo "Done!"

--- a/rhino-deinst
+++ b/rhino-deinst
@@ -178,6 +178,13 @@ if [[ -n $remove_packages ]]; then
     echo "Removing unnecessary packages"
     sudo apt remove -y ${remove_packages}
 fi
+if [[ ${desktop[@]} = "unity" ]]; then
+  echo "Installing Unity 7.6"
+  sudo wget https://repo.unityx.org/unityx.key
+  sudo apt-key add unityx.key
+  echo 'deb https://repo.unityx.org/main testing main' | sudo tee /etc/apt/sources.list.d/unity-x.list
+  sudo apt-get update && sudo apt-get install -y unity
+  fi
 echo "Set login manager to $login_manager"
 sudo dpkg-reconfigure "${login_manager}"
 echo "Done!"


### PR DESCRIPTION
This is something I tested in my own fork for the Unity package until something more permanent is proposed. When installing `unity`, Ubuntu will install GNOME apps by default because that is something Ubuntu does. This addition will remove GNOME apps when Unity is chosen as the desktop environment, so the user doesn't have to go through the trouble of removing the package themselves.

NEW: Tested on my own fork, I have updated the Unity option again so now when the user chooses Unity as the DE, this will install Unity 7.6, the first major release to Unity in 6 years. Note that this only affects `Unity`, not `Unity (Ubuntu)`