### PR TITLE
Fix issues with dialog with empty output

### DIFF
--- a/rhino-deinst
+++ b/rhino-deinst
@@ -6,7 +6,7 @@ if ! command -v dialog > /dev/null; then
   sudo apt-get install dialog -y
 fi
 
-SELECTED=($( dialog --backtitle "Press 'space' to toggle an option, use arrow keys to go up/down, press enter to continue" --erase-on-exit --scrollbar --separate-output --checklist "Select Desktop Environment(s)" 10 35 5 \
+SELECTED=($( dialog --backtitle "Press 'space' to toggle an option, use arrow keys to go up/down, press enter to continue" --scrollbar --separate-output --checklist "Select Desktop Environment(s)" 10 35 5 \
   "1" "GNOME (Ubuntu)" OFF \
   "2" "GNOME Flashback" OFF \
   "3" "GNOME" OFF \
@@ -176,3 +176,4 @@ sudo apt-get install -y ${desktop[@]} "${login_manager}" ${extra_packages}
 echo "Set login manager to $login_manager"
 sudo dpkg-reconfigure "${login_manager}"
 echo "Done!"
+clear


### PR DESCRIPTION
This fixes an issue that makes it where --erase-on-exit shows this:
![image](https://user-images.githubusercontent.com/62823569/172030531-ed462f91-7708-423f-9af7-56c2d9b8ae18.png)

Here's the broken version
```#!/bin/bash
set -e

if ! command -v dialog > /dev/null; then
  echo "dialog is not installed, installing..." >&2
  sudo apt-get install dialog -y
fi

SELECTED=($( dialog --backtitle "Press 'space' to toggle an option, use arrow keys to go up/down, press enter to continue" --erase-on-exit --scrollbar --separate-output --checklist "Select Desktop Environment(s)" 10 35 5 \
  "1" "GNOME (Ubuntu)" OFF \
  "2" "GNOME Flashback" OFF \
  "3" "GNOME" OFF \
  "4" "KDE (Full)" OFF \
  "5" "KDE (Standard)" OFF \
  "6" "XFCE (Ubuntu)" OFF \
  "7" "XFCE" OFF \
  "8" "MATE (Ubuntu)" OFF \
  "9" "MATE" OFF \
  "10" "LXQt (Ubuntu)" OFF \
  "11" "LXQt" OFF \
  "12" "Budgie (Ubuntu)" OFF \
  "13" "Budgie" OFF \
  "14" "Unity (Ubuntu)" OFF \
  "15" "Unity" OFF \
  "16" "Cinnamon" OFF \
  "17" "Phosh core" OFF \
  "18" "UKUI" OFF \
  "19" "LXDE" OFF \
  "20" "i3" OFF \
  "21" "Sway" OFF \
  "22" "AwesomeWM" OFF \
  "23" "bspwm" OFF \
  "24" "DWM" OFF \
  "25" "Openbox" OFF \
  "26" "Enlightenment" OFF \
  3>&1 1>&2 2>&3))

for i in "${SELECTED[@]}"; do
  case $i in
    1)
      desktop+=("ubuntu-desktop")
      login_manager="gdm3"
      ;;
    2)
      desktop+=("gnome-session-flashback")
      login_manager="gdm3"
      ;;
    3)
      desktop+=("vanilla-gnome-desktop")
      login_manager="gdm3"
      ;;
    4)
      desktop+=("kde-full")
      login_manager="sddm"
      ;;
    5)
      desktop+=("kde-standard")
      login_manager="sddm"
      ;;
    6)
      desktop+=("xubuntu-desktop")
      login_manager="lightdm"
      ;;
    7)
      desktop+=("xfce4" "xfce4-goodies")
      login_manager="lightdm"
      ;;
    8)
      desktop+=("ubuntu-mate-desktop")
      login_manager="lightdm"
      ;;
    9)
      desktop+=("mate-desktop")
      login_manager="lightdm"
      ;;
    10)
      desktop+=("lubuntu-desktop")
      login_manager="sddm"
      ;;
    11)
      desktop+=("lxqt")
      login_manager="sddm"
      ;;
    12)
      desktop+=("ubuntu-budgie-desktop")
      login_manager="budgie-lightdm-theme-base"
      
      ;;
    13)
      desktop+=("budgie-desktop")
      login_manager="budgie-lightdm-theme-base"
      ;; 
    14)
      desktop+=("ubuntu-unity-desktop")
      login_manager="lightdm"
      extra_packages="dbus-x11 yaru-theme-unity unity-tweak-tool"
      ;;
    15)
      desktop+=("unity")
      login_manager="lightdm"
      extra_packages="dbus-x11 yaru-theme-unity unity-tweak-tool unity-lens-applications unity-lens-files unity-scopes-runner libzeitgeist-1.0-1 unity-accessibility-profiles vlc pluma mate-system-monitor atril eom"
      ;;
    16)
      desktop+=("cinnamon")
      login_manager="lightdm"
      ;; 
    17)
      desktop+=("phose-core")
      login_manager="gdm3"
      ;;
    18)
      desktop+=("ukui-desktop-environment")
      login_manager="ukui-greeter"
      extra_packages="obconf"
      ;;
    19)
      desktop+=("lxde")
      login_manager="lxdm"
      ;;
    20)
      desktop+=("i3")
      login_manager="lightdm"
      ;; 
    21)
      desktop+=("sway")
      login_manager="sddm"
      ;; 
    22)
      desktop+=("awesome")
      login_manager="lightdm"
      ;;
    23)
      desktop+=("bspwm")
      login_manager="lightdm"
      ;;
    24)
      desktop+=("dwm")
      login_manager="lightdm"
      ;;
    25)
      desktop+=("openbox")
      login_manager="lightdm"
      extra_packages="obconf"
      ;;
    26)
      desktop+=("enlightenment")
      login_manager="lightdm"
      ;;
  esac
done

clear

echo "Updating package cache..."
sudo apt-get update

echo "Checking for package existence..."
for i in "${desktop[@]}"; do
  if [[ $(apt-cache search --names-only "^$i\$") ]]; then
    echo "$i exists..."
  else
    echo "$i does not exist, exiting..." >&2
    exit 1
  fi
done

if [[ $(apt-cache search --names-only "^$login_manager\$") ]]; then
  echo "$i exists..."
else
  echo "$i does not exist, exiting..." >&2
  exit 1
fi

echo "Installing desktop and login manager..."
sudo apt-get install -y ${desktop[@]} "${login_manager}" ${extra_packages}
echo "Set login manager to $login_manager"
sudo dpkg-reconfigure "${login_manager}"
echo `"Done!"
```

Here's the fixed version gif:
![FixedVersion](https://user-images.githubusercontent.com/62823569/172030680-10471914-adb4-4e1d-a380-6049b22365e4.gif)


and Here's the fixed version's code:
```#!/bin/bash
set -e

if ! command -v dialog > /dev/null; then
  echo "dialog is not installed, installing..." >&2
  sudo apt-get install dialog -y
fi

SELECTED=($( dialog --backtitle "Press 'space' to toggle an option, use arrow keys to go up/down, press enter to continue" --scrollbar --separate-output --checklist "Select Desktop Environment(s)" 10 35 5 \
  "1" "GNOME (Ubuntu)" OFF \
  "2" "GNOME Flashback" OFF \
  "3" "GNOME" OFF \
  "4" "KDE (Full)" OFF \
  "5" "KDE (Standard)" OFF \
  "6" "XFCE (Ubuntu)" OFF \
  "7" "XFCE" OFF \
  "8" "MATE (Ubuntu)" OFF \
  "9" "MATE" OFF \
  "10" "LXQt (Ubuntu)" OFF \
  "11" "LXQt" OFF \
  "12" "Budgie (Ubuntu)" OFF \
  "13" "Budgie" OFF \
  "14" "Unity (Ubuntu)" OFF \
  "15" "Unity" OFF \
  "16" "Cinnamon" OFF \
  "17" "Phosh core" OFF \
  "18" "UKUI" OFF \
  "19" "LXDE" OFF \
  "20" "i3" OFF \
  "21" "Sway" OFF \
  "22" "AwesomeWM" OFF \
  "23" "bspwm" OFF \
  "24" "DWM" OFF \
  "25" "Openbox" OFF \
  "26" "Enlightenment" OFF \
  3>&1 1>&2 2>&3))

for i in "${SELECTED[@]}"; do
  case $i in
    1)
      desktop+=("ubuntu-desktop")
      login_manager="gdm3"
      ;;
    2)
      desktop+=("gnome-session-flashback")
      login_manager="gdm3"
      ;;
    3)
      desktop+=("vanilla-gnome-desktop")
      login_manager="gdm3"
      ;;
    4)
      desktop+=("kde-full")
      login_manager="sddm"
      ;;
    5)
      desktop+=("kde-standard")
      login_manager="sddm"
      ;;
    6)
      desktop+=("xubuntu-desktop")
      login_manager="lightdm"
      ;;
    7)
      desktop+=("xfce4" "xfce4-goodies")
      login_manager="lightdm"
      ;;
    8)
      desktop+=("ubuntu-mate-desktop")
      login_manager="lightdm"
      ;;
    9)
      desktop+=("mate-desktop")
      login_manager="lightdm"
      ;;
    10)
      desktop+=("lubuntu-desktop")
      login_manager="sddm"
      ;;
    11)
      desktop+=("lxqt")
      login_manager="sddm"
      ;;
    12)
      desktop+=("ubuntu-budgie-desktop")
      login_manager="budgie-lightdm-theme-base"
      
      ;;
    13)
      desktop+=("budgie-desktop")
      login_manager="budgie-lightdm-theme-base"
      ;; 
    14)
      desktop+=("ubuntu-unity-desktop")
      login_manager="lightdm"
      extra_packages="dbus-x11 yaru-theme-unity unity-tweak-tool"
      ;;
    15)
      desktop+=("unity")
      login_manager="lightdm"
      extra_packages="dbus-x11 yaru-theme-unity unity-tweak-tool unity-lens-applications unity-lens-files unity-scopes-runner libzeitgeist-1.0-1 unity-accessibility-profiles vlc pluma mate-system-monitor atril eom"
      ;;
    16)
      desktop+=("cinnamon")
      login_manager="lightdm"
      ;; 
    17)
      desktop+=("phose-core")
      login_manager="gdm3"
      ;;
    18)
      desktop+=("ukui-desktop-environment")
      login_manager="ukui-greeter"
      extra_packages="obconf"
      ;;
    19)
      desktop+=("lxde")
      login_manager="lxdm"
      ;;
    20)
      desktop+=("i3")
      login_manager="lightdm"
      ;; 
    21)
      desktop+=("sway")
      login_manager="sddm"
      ;; 
    22)
      desktop+=("awesome")
      login_manager="lightdm"
      ;;
    23)
      desktop+=("bspwm")
      login_manager="lightdm"
      ;;
    24)
      desktop+=("dwm")
      login_manager="lightdm"
      ;;
    25)
      desktop+=("openbox")
      login_manager="lightdm"
      extra_packages="obconf"
      ;;
    26)
      desktop+=("enlightenment")
      login_manager="lightdm"
      ;;
  esac
done

clear

echo "Updating package cache..."
sudo apt-get update

echo "Checking for package existence..."
for i in "${desktop[@]}"; do
  if [[ $(apt-cache search --names-only "^$i\$") ]]; then
    echo "$i exists..."
  else
    echo "$i does not exist, exiting..." >&2
    exit 1
  fi
done

if [[ $(apt-cache search --names-only "^$login_manager\$") ]]; then
  echo "$i exists..."
else
  echo "$i does not exist, exiting..." >&2
  exit 1
fi

echo "Installing desktop and login manager..."
sudo apt-get install -y ${desktop[@]} "${login_manager}" ${extra_packages}
echo "Set login manager to $login_manager"
sudo dpkg-reconfigure "${login_manager}"
echo "Done!"
clear
```
For more evidence:
![image](https://user-images.githubusercontent.com/62823569/172030801-ed07d85c-e09d-4dee-9c39-daa39bac071a.png)

Hence why I made this fix