### PR TITLE
feat: rhino-deinst tweaks

### DIFF
--- a/rhino-deinst
+++ b/rhino-deinst
@@ -10,28 +10,29 @@ SELECTED=($( dialog --backtitle "Press 'space' to toggle an option, use arrow ke
   "1" "GNOME (Ubuntu)" OFF \
   "2" "GNOME Flashback" OFF \
   "3" "GNOME" OFF \
-  "4" "KDE (Full)" OFF \
-  "5" "KDE (Standard)" OFF \
-  "6" "XFCE (Ubuntu)" OFF \
-  "7" "XFCE" OFF \
-  "8" "MATE (Ubuntu)" OFF \
-  "9" "MATE" OFF \
-  "10" "LXQt (Ubuntu)" OFF \
-  "11" "LXQt" OFF \
-  "12" "Budgie (Ubuntu)" OFF \
-  "13" "Budgie" OFF \
-  "14" "Unity" OFF \
-  "15" "Cinnamon" OFF \
-  "16" "Phosh core" OFF \
-  "17" "UKUI" OFF \
-  "18" "LXDE" OFF \
-  "19" "i3" OFF \
-  "20" "Sway" OFF \
-  "21" "AwesomeWM" OFF \
-  "22" "bspwm" OFF \
-  "23" "DWM" OFF \
-  "24" "Openbox" OFF \
-  "25" "Enlightenment" OFF \
+  "4" "KDE (Ubuntu)" OFF \
+  "5" "KDE (Full)" OFF \
+  "6" "KDE (Standard)" OFF \
+  "7" "XFCE (Ubuntu)" OFF \
+  "8" "XFCE" OFF \
+  "9" "MATE (Ubuntu)" OFF \
+  "10" "MATE" OFF \
+  "11" "LXQt (Ubuntu)" OFF \
+  "12" "LXQt" OFF \
+  "13" "Budgie (Ubuntu)" OFF \
+  "14" "Budgie" OFF \
+  "15" "Unity" OFF \
+  "16" "Cinnamon" OFF \
+  "17" "Phosh core" OFF \
+  "18" "UKUI" OFF \
+  "19" "LXDE" OFF \
+  "20" "i3" OFF \
+  "21" "Sway" OFF \
+  "22" "AwesomeWM" OFF \
+  "23" "bspwm" OFF \
+  "24" "DWM" OFF \
+  "25" "Openbox" OFF \
+  "26" "Enlightenment" OFF \
   3>&1 1>&2 2>&3))
 
 for i in "${SELECTED[@]}"; do
@@ -49,95 +50,98 @@ for i in "${SELECTED[@]}"; do
       login_manager="gdm3"
       ;;
     4)
+      desktop+=("kubuntu-desktop")
+      login_manager="sddm"
+      ;;      
+    5)
       desktop+=("kde-full")
       login_manager="sddm"
       ;;
-    5)
+    6)
       desktop+=("kde-standard")
       login_manager="sddm"
       ;;
-    6)
+    7)
       desktop+=("xubuntu-desktop")
       login_manager="lightdm"
       ;;
-    7)
+    8)
       desktop+=("xfce4" "xfce4-goodies")
       login_manager="lightdm"
       ;;
-    8)
+    9)
       desktop+=("ubuntu-mate-desktop")
       login_manager="lightdm"
       ;;
-    9)
+    10)
       desktop+=("mate-desktop")
       login_manager="lightdm"
       ;;
-    10)
+    11)
       desktop+=("lubuntu-desktop")
       login_manager="sddm"
       ;;
-    11)
+    12)
       desktop+=("lxqt")
       login_manager="sddm"
       ;;
-    12)
+    13)
       desktop+=("ubuntu-budgie-desktop")
       login_manager="budgie-lightdm-theme-base"
-      
       ;;
-    13)
+    14)
       desktop+=("budgie-desktop")
       login_manager="budgie-lightdm-theme-base"
       ;; 
-    14)
+    15)
       desktop+=("ubuntu-unity-desktop")
       login_manager="lightdm"
       extra_packages="dbus-x11 yaru-theme-unity yaru-theme-icon yaru-theme-gtk yaru-theme-sound unity-tweak-tool atril eom vlc pluma mate-system-monitor unity-lens-music unity-lens-photos unity-lens-video"
       remove_packages="totem eog nautilus gnome-system-monitor gnome-text-editor gedit"
       ;;
-    15)
+    16)
       desktop+=("cinnamon")
       login_manager="lightdm"
       ;; 
-    16)
+    17)
       desktop+=("phose-core")
       login_manager="gdm3"
       ;;
-    17)
+    18)
       desktop+=("ukui-desktop-environment")
       login_manager="ukui-greeter"
       extra_packages="obconf"
       ;;
-    18)
+    19)
       desktop+=("lxde")
       login_manager="lxdm"
       ;;
-    19)
+    20)
       desktop+=("i3")
       login_manager="lightdm"
       ;; 
-    20)
+    21)
       desktop+=("sway")
       login_manager="sddm"
       ;; 
-    21)
+    22)
       desktop+=("awesome")
       login_manager="lightdm"
       ;;
-    22)
+    23)
       desktop+=("bspwm")
       login_manager="lightdm"
       ;;
-    23)
+    24)
       desktop+=("dwm")
       login_manager="lightdm"
       ;;
-    24)
+    25)
       desktop+=("openbox")
       login_manager="lightdm"
       extra_packages="obconf"
       ;;
-    25)
+    26)
       desktop+=("enlightenment")
       login_manager="lightdm"
       ;;

--- a/rhino-deinst
+++ b/rhino-deinst
@@ -92,8 +92,8 @@ for i in "${SELECTED[@]}"; do
     14)
       desktop+=("ubuntu-unity-desktop")
       login_manager="lightdm"
-      extra_packages="dbus-x11 yaru-theme-unity unity-tweak-tool"
-      remove_packages="totem eog nautilus gnome-system-monitor gnome-text-editor gedit"
+      extra_packages="dbus-x11 yaru-theme-unity yaru-theme-icon yaru-theme-gtk yaru-theme-sound unity-tweak-tool atril eom vlc pluma mate-system-monitor"
+      remove_packages="totem eog nautilus gnome-system-monitor gnome-text-editor gedit ubuntu-unity-desktop"
       ;;
     15)
       desktop+=("cinnamon")
@@ -168,10 +168,6 @@ fi
 
 echo "Installing desktop and login manager..."
 sudo apt-get install -y ${desktop[@]} "${login_manager}" ${extra_packages}
-if [[ -n $remove_packages ]]; then
-    echo "Removing unnecessary packages"
-    sudo apt remove -y ${remove_packages}
-fi
 if [[ ${desktop[@]} = "ubuntu-unity-desktop" ]]; then
   echo "Installing Unity 7.6"
   sudo wget https://repo.unityx.org/unityx.key
@@ -179,6 +175,10 @@ if [[ ${desktop[@]} = "ubuntu-unity-desktop" ]]; then
   echo 'deb https://repo.unityx.org/main testing main' | sudo tee /etc/apt/sources.list.d/unity-x.list
   sudo apt-get update && sudo apt-get install -y unity
   fi
+if [[ -n $remove_packages ]]; then
+    echo "Removing unnecessary packages"
+    sudo apt remove -y ${remove_packages}
+fi
 echo "Set login manager to $login_manager"
 sudo dpkg-reconfigure "${login_manager}"
 echo "Done!"

--- a/rhino-deinst
+++ b/rhino-deinst
@@ -184,7 +184,7 @@ if [[ -n $remove_packages ]]; then
     sudo apt remove -y ${remove_packages}
     sudo apt autoremove -y
 fi
-if false ! [[ ${desktop[@]} == "ubuntu-desktop gnome-session-flashback vanilla-gnome-desktop" ]]; then
+if ! [[ ${desktop[@]} == "ubuntu-desktop gnome-session-flashback vanilla-gnome-desktop" ]]; then
   echo "Removing gnome-shell"
   sudo apt autoremove '^gnome-shell' --purge -y
 fi

--- a/rhino-deinst
+++ b/rhino-deinst
@@ -93,7 +93,7 @@ for i in "${SELECTED[@]}"; do
       desktop+=("ubuntu-unity-desktop")
       login_manager="lightdm"
       extra_packages="dbus-x11 yaru-theme-unity yaru-theme-icon yaru-theme-gtk yaru-theme-sound unity-tweak-tool atril eom vlc pluma mate-system-monitor unity-lens-music"
-      remove_packages="totem eog nautilus gnome-system-monitor gnome-text-editor gedit ubuntu-unity-desktop"
+      remove_packages="totem eog nautilus gnome-system-monitor gnome-text-editor gedit"
       ;;
     15)
       desktop+=("cinnamon")

--- a/rhino-deinst
+++ b/rhino-deinst
@@ -168,7 +168,7 @@ fi
 
 echo "Installing desktop and login manager..."
 sudo apt-get install -y ${desktop[@]} "${login_manager}" ${extra_packages}
-if [[ ${desktop[@]} = "ubuntu-unity-desktop" ]]; then
+if [[ ${desktop[@]} == "ubuntu-unity-desktop" ]]; then
   echo "Installing Unity 7.6"
   sudo wget https://repo.unityx.org/unityx.key
   sudo apt-key add unityx.key

--- a/rhino-deinst
+++ b/rhino-deinst
@@ -180,6 +180,10 @@ if [[ -n $remove_packages ]]; then
     sudo apt remove -y ${remove_packages}
     sudo apt autoremove -y
 fi
+if false ! [[ ${desktop[@]} == "ubuntu-desktop gnome-session-flashback vanilla-gnome-desktop" ]]; then
+  echo "Removing gnome-shell"
+  sudo apt autoremove '^gnome-shell' --purge -y
+fi
 echo "Set login manager to $login_manager"
 sudo dpkg-reconfigure "${login_manager}"
 echo "Done!"

--- a/rhino-deinst
+++ b/rhino-deinst
@@ -21,18 +21,17 @@ SELECTED=($( dialog --backtitle "Press 'space' to toggle an option, use arrow ke
   "12" "Budgie (Ubuntu)" OFF \
   "13" "Budgie" OFF \
   "14" "Unity (Ubuntu)" OFF \
-  "15" "Unity" OFF \
-  "16" "Cinnamon" OFF \
-  "17" "Phosh core" OFF \
-  "18" "UKUI" OFF \
-  "19" "LXDE" OFF \
-  "20" "i3" OFF \
-  "21" "Sway" OFF \
-  "22" "AwesomeWM" OFF \
-  "23" "bspwm" OFF \
-  "24" "DWM" OFF \
-  "25" "Openbox" OFF \
-  "26" "Enlightenment" OFF \
+  "15" "Cinnamon" OFF \
+  "16" "Phosh core" OFF \
+  "17" "UKUI" OFF \
+  "18" "LXDE" OFF \
+  "19" "i3" OFF \
+  "20" "Sway" OFF \
+  "21" "AwesomeWM" OFF \
+  "22" "bspwm" OFF \
+  "23" "DWM" OFF \
+  "24" "Openbox" OFF \
+  "25" "Enlightenment" OFF \
   3>&1 1>&2 2>&3))
 
 for i in "${SELECTED[@]}"; do
@@ -96,53 +95,48 @@ for i in "${SELECTED[@]}"; do
       extra_packages="dbus-x11 yaru-theme-unity unity-tweak-tool"
       ;;
     15)
-      desktop+=("unity")
-      login_manager="lightdm"
-      extra_packages="dbus-x11 yaru-theme-unity unity-tweak-tool unity-lens-applications unity-lens-files unity-scopes-runner libzeitgeist-1.0-1 unity-accessibility-profiles vlc pluma mate-system-monitor atril eom"
-      ;;
-    16)
       desktop+=("cinnamon")
       login_manager="lightdm"
       ;; 
-    17)
+    16)
       desktop+=("phose-core")
       login_manager="gdm3"
       ;;
-    18)
+    17)
       desktop+=("ukui-desktop-environment")
       login_manager="ukui-greeter"
       extra_packages="obconf"
       ;;
-    19)
+    18)
       desktop+=("lxde")
       login_manager="lxdm"
       ;;
-    20)
+    19)
       desktop+=("i3")
       login_manager="lightdm"
       ;; 
-    21)
+    20)
       desktop+=("sway")
       login_manager="sddm"
       ;; 
-    22)
+    21)
       desktop+=("awesome")
       login_manager="lightdm"
       ;;
-    23)
+    22)
       desktop+=("bspwm")
       login_manager="lightdm"
       ;;
-    24)
+    23)
       desktop+=("dwm")
       login_manager="lightdm"
       ;;
-    25)
+    24)
       desktop+=("openbox")
       login_manager="lightdm"
       extra_packages="obconf"
       ;;
-    26)
+    25)
       desktop+=("enlightenment")
       login_manager="lightdm"
       ;;

--- a/rhino-deinst
+++ b/rhino-deinst
@@ -88,10 +88,12 @@ for i in "${SELECTED[@]}"; do
     13)
       desktop+=("ubuntu-budgie-desktop")
       login_manager="budgie-lightdm-theme-base"
+      extra_packages="budgie-extras-common budgie-extras-daemon"
       ;;
     14)
       desktop+=("budgie-desktop")
       login_manager="budgie-lightdm-theme-base"
+      extra_packages="budgie-extras-common budgie-extras-daemon"
       ;; 
     15)
       desktop+=("ubuntu-unity-desktop")

--- a/rhino-deinst
+++ b/rhino-deinst
@@ -92,7 +92,7 @@ for i in "${SELECTED[@]}"; do
     14)
       desktop+=("ubuntu-unity-desktop")
       login_manager="lightdm"
-      extra_packages="dbus-x11 yaru-theme-unity yaru-theme-icon yaru-theme-gtk yaru-theme-sound unity-tweak-tool atril eom vlc pluma mate-system-monitor"
+      extra_packages="dbus-x11 yaru-theme-unity yaru-theme-icon yaru-theme-gtk yaru-theme-sound unity-tweak-tool atril eom vlc pluma mate-system-monitor unity-lens-music"
       remove_packages="totem eog nautilus gnome-system-monitor gnome-text-editor gedit ubuntu-unity-desktop"
       ;;
     15)
@@ -178,6 +178,7 @@ if [[ ${desktop[@]} = "ubuntu-unity-desktop" ]]; then
 if [[ -n $remove_packages ]]; then
     echo "Removing unnecessary packages"
     sudo apt remove -y ${remove_packages}
+    sudo apt autoremove -y
 fi
 echo "Set login manager to $login_manager"
 sudo dpkg-reconfigure "${login_manager}"

--- a/rhino-deinst
+++ b/rhino-deinst
@@ -93,6 +93,7 @@ for i in "${SELECTED[@]}"; do
       desktop+=("ubuntu-unity-desktop")
       login_manager="lightdm"
       extra_packages="dbus-x11 yaru-theme-unity unity-tweak-tool"
+      remove_packages="totem eog nautilus gnome-system-monitor gnome-text-editor gedit"
       ;;
     15)
       desktop+=("cinnamon")
@@ -167,6 +168,17 @@ fi
 
 echo "Installing desktop and login manager..."
 sudo apt-get install -y ${desktop[@]} "${login_manager}" ${extra_packages}
+if [[ -n $remove_packages ]]; then
+    echo "Removing unnecessary packages"
+    sudo apt remove -y ${remove_packages}
+fi
+if [[ ${desktop[@]} = "ubuntu-unity-desktop" ]]; then
+  echo "Installing Unity 7.6"
+  sudo wget https://repo.unityx.org/unityx.key
+  sudo apt-key add unityx.key
+  echo 'deb https://repo.unityx.org/main testing main' | sudo tee /etc/apt/sources.list.d/unity-x.list
+  sudo apt-get update && sudo apt-get install -y unity
+  fi
 echo "Set login manager to $login_manager"
 sudo dpkg-reconfigure "${login_manager}"
 echo "Done!"

--- a/rhino-deinst
+++ b/rhino-deinst
@@ -89,6 +89,7 @@ for i in "${SELECTED[@]}"; do
       desktop+=("ubuntu-budgie-desktop")
       login_manager="budgie-lightdm-theme-base"
       extra_packages="budgie-extras-common budgie-extras-daemon"
+      snap_package_classic="ubuntu-budgie-welcome"
       ;;
     14)
       desktop+=("budgie-desktop")
@@ -181,6 +182,10 @@ if [[ ${desktop[@]} == "ubuntu-unity-desktop" ]]; then
   echo 'deb https://repo.unityx.org/main testing main' | sudo tee /etc/apt/sources.list.d/unity-x.list
   sudo apt-get update && sudo apt-get install -y unity
   fi
+if [[ ${desktop[@]} == "ubuntu-budgie-desktop" ]]; then
+  echo "Installing needed Snaps"
+  sudo snap install ${snap_package_classic} --classic
+fi
 if [[ -n $remove_packages ]]; then
     echo "Removing unnecessary packages"
     sudo apt remove -y ${remove_packages}

--- a/rhino-deinst
+++ b/rhino-deinst
@@ -20,7 +20,7 @@ SELECTED=($( dialog --backtitle "Press 'space' to toggle an option, use arrow ke
   "11" "LXQt" OFF \
   "12" "Budgie (Ubuntu)" OFF \
   "13" "Budgie" OFF \
-  "14" "Unity (Ubuntu)" OFF \
+  "14" "Unity" OFF \
   "15" "Cinnamon" OFF \
   "16" "Phosh core" OFF \
   "17" "UKUI" OFF \
@@ -92,7 +92,7 @@ for i in "${SELECTED[@]}"; do
     14)
       desktop+=("ubuntu-unity-desktop")
       login_manager="lightdm"
-      extra_packages="dbus-x11 yaru-theme-unity yaru-theme-icon yaru-theme-gtk yaru-theme-sound unity-tweak-tool atril eom vlc pluma mate-system-monitor unity-lens-music"
+      extra_packages="dbus-x11 yaru-theme-unity yaru-theme-icon yaru-theme-gtk yaru-theme-sound unity-tweak-tool atril eom vlc pluma mate-system-monitor unity-lens-music unity-lens-photos unity-lens-video"
       remove_packages="totem eog nautilus gnome-system-monitor gnome-text-editor gedit"
       ;;
     15)


### PR DESCRIPTION
Made some more adjustments with the tool

1. Added `remove_packages`. Within this flag, it'll remove the packages that are marked for removal, and then clean up useless packages with `sudo apt autoremove -y`.
2. Added packages to `extra_packages` to `Unity (Ubuntu)` so now MATE and Yaru packages are installed with the Unity desktop
3. Reworked how Unity gets installed, so now Unity shouldn't be installed incomplete. With that, the `Unity` only option was removed, and `Unity (Ubuntu)` became the new `Unity` only option. Furthermore, Unity will now install Unity 7.6, the latest iteration of the Unity desktop by Rudra Saraswat.
4. Added `unity-lens-video`, `unity-lens-photos`, and `unity-lens-music` to `extra_packages` to provide the missing packages to make photos, videos, and music work in the Unity dash
![Screenshot from 2022-06-07 11-50-07](https://user-images.githubusercontent.com/50627538/172425859-6d3c4f61-c1dc-436a-a132-e0643b09daa2.png)
5. Now, if `GNOME (Ubuntu)`, `GNOME Flashback`, or `GNOME` is not installed as any of the selections, rhino-deinst will purge all traces of GNOME. This addition is because whenever a desktop environment is installed on a minimal install, Ubuntu will install `ubuntu-desktop`, no matter what is selected. For users that decide to install any of the GNOME selections, they'll be able to do with `ubuntu-desktop` as they wish
6. Added `kubuntu-desktop` as `KDE (Ubuntu)` in rhino-deinst
7. Added `budgie-extras-common` and `budgie-extras-daemon` to both Budgie options in rhino-deinst
8. Added `snap_package_classic` for `Budgie (Ubuntu)`