### PR TITLE
add: `ubuntu-mate-welcome`

### DIFF
--- a/rhino-deinst
+++ b/rhino-deinst
@@ -72,6 +72,7 @@ for i in "${SELECTED[@]}"; do
     9)
       desktop+=("ubuntu-mate-desktop")
       login_manager="lightdm"
+      snap_package_classic="ubuntu-mate-welcome"
       ;;
     10)
       desktop+=("mate-desktop")
@@ -182,8 +183,7 @@ if [[ ${desktop[@]} == "ubuntu-unity-desktop" ]]; then
   echo 'deb https://repo.unityx.org/main testing main' | sudo tee /etc/apt/sources.list.d/unity-x.list
   sudo apt-get update && sudo apt-get install -y unity
   fi
-if [[ ${desktop[@]} == "ubuntu-budgie-desktop" ]]; then
-  echo "Installing needed Snaps"
+if [[ -n $snap_package_classic ]]; then
   sudo snap install ${snap_package_classic} --classic
 fi
 if [[ -n $remove_packages ]]; then

--- a/rhino-deinst
+++ b/rhino-deinst
@@ -184,6 +184,7 @@ if [[ ${desktop[@]} == "ubuntu-unity-desktop" ]]; then
   sudo apt-get update && sudo apt-get install -y unity
   fi
 if [[ -n $snap_package_classic ]]; then
+  sudo apt-get install snapd -y
   sudo snap install ${snap_package_classic} --classic
 fi
 if [[ -n $remove_packages ]]; then


### PR DESCRIPTION
This adds the Ubuntu MATE welcome screen to `MATE (Ubuntu)`. This is a snap dependency, so if this gets merged, I'll update the rhino-deinst wiki accordingly